### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/intellum/neeman.svg)](https://travis-ci.org/intellum/neeman)
 [![Docs](https://img.shields.io/cocoapods/metrics/doc-percent/Neeman.svg)](http://cocoadocs.org/docsets/Neeman)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/Neeman.svg)](https://img.shields.io/cocoapods/v/Neeman.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Neeman.svg)](https://img.shields.io/cocoapods/v/Neeman.svg)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Platform](https://img.shields.io/cocoapods/p/Neeman.svg?style=flat)](http://cocoadocs.org/docsets/Neeman)
 [![License](https://img.shields.io/cocoapods/l/Neeman.svg?style=flat)](https://raw.githubusercontent.com/intellum/neeman/master/LICENSE)


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
